### PR TITLE
renderer_vulkan: Clear blank frame

### DIFF
--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -602,6 +602,28 @@ Frame* Presenter::PrepareFrameInternal(VideoCore::ImageId image_id, bool is_eop)
         cmdbuf.beginRendering(rendering_info);
         cmdbuf.draw(3, 1, 0, 0);
         cmdbuf.endRendering();
+    } else {
+        // Fix display of garbage images on startup on some drivers
+        const std::array attachments = {vk::RenderingAttachmentInfo{
+            .imageView = frame->image_view,
+            .imageLayout = vk::ImageLayout::eColorAttachmentOptimal,
+            .loadOp = vk::AttachmentLoadOp::eClear,
+            .storeOp = vk::AttachmentStoreOp::eStore,
+        }};
+
+        vk::RenderingInfo rendering_info{
+            .renderArea =
+                vk::Rect2D{
+                    .offset = {0, 0},
+                    .extent = {frame->width, frame->height},
+                },
+            .layerCount = 1,
+            .colorAttachmentCount = attachments.size(),
+            .pColorAttachments = attachments.data(),
+        };
+
+        cmdbuf.beginRendering(rendering_info);
+        cmdbuf.endRendering();
     }
 
     const auto post_barrier =


### PR DESCRIPTION
Fix display of garbage images on startup on some drivers.